### PR TITLE
Fix memory leak on resize

### DIFF
--- a/src/AvaloniaInside.MonoGame/ResolutionRenderer.cs
+++ b/src/AvaloniaInside.MonoGame/ResolutionRenderer.cs
@@ -88,6 +88,8 @@ namespace AvaloniaInside.MonoGame;
             _needsUpdate = false;
 
             _scale = ScreenResolution.ToVector2() / VirtualResolution.ToVector2();
+            
+            try { _target?.Dispose(); } catch (Exception) { /* ignore */ }
             _target = new RenderTarget2D(_device, _virtualResolution.X, _virtualResolution.Y);
 
             switch(_method)


### PR DESCRIPTION
This adds an error trapped dispose to the render target when resizing occurs. 
This should prevent the memory leak when resizing.

Thanks for this great control!